### PR TITLE
CI: Add basic CI/CD pipeline

### DIFF
--- a/.github/workflows/test-first-image.yaml
+++ b/.github/workflows/test-first-image.yaml
@@ -1,0 +1,30 @@
+# This action builds and tests a basic image, as described here:
+# https://canonical-risc-v-cookbook.readthedocs-hosted.com/en/latest/tutorial/create_image/
+name: Build and test
+
+# We allow running workflows on main, and on the 'ci' special branch used to work
+# on ci/cd workflows.
+on:
+  push:
+    branches:
+      - main
+      - ci
+  pull_request:
+    branches:
+      - main
+      - ci
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Install apt dependencies
+        run: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y snapd qemu-user-static ubuntu-dev-tools
+      - name: Refresh systemd-binfmt
+        run: sudo systemctl restart systemd-binfmt
+      - name: Install ubuntu-image
+        run: sudo snap install --classic ubuntu-image
+      - name: Build image
+        run: sudo ubuntu-image --workdir work --debug classic image-definition.yaml

--- a/.github/workflows/test-first-image.yaml
+++ b/.github/workflows/test-first-image.yaml
@@ -28,3 +28,13 @@ jobs:
         run: sudo snap install --classic ubuntu-image
       - name: Build image
         run: sudo ubuntu-image --workdir work --debug classic image-definition.yaml
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-24.04-preinstalled-server-riscv64.img
+          path: work/ubuntu-24.04-preinstalled-server-riscv64.img
+      - name: Upload manifest as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-24.04-preinstalled-server-riscv64.manifest
+          path: work/ubuntu-24.04-preinstalled-server-riscv64.manifest

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,8 @@ install/dtb:
 install/grub:
 	rm -rf build
 	mkdir build
-	# Monolithic images are not yet backported to Ubuntu 22.04.
 	cd build && pull-lp-debs -a riscv64 grub2 $(SERIES)
-	cd build && dpkg -x grub-efi-riscv64-unsigned*.deb grub/
+	cd build && dpkg -x grub-efi-riscv64-bin*.deb grub/
 	mkdir -p $(DESTDIR)/grub
 	cp ./build/grub/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi $(DESTDIR)/grub/
 	cp grub.cfg $(DESTDIR)/grub/

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install/cidata:
 install/dtb:
 	rm -rf build
 	mkdir build
-	cd build && pull-lp-debs -a riscv64 linux-riscv '' $(SERIES)
+	cd build && pull-lp-debs -a riscv64 linux-riscv $(SERIES)
 	cd build && dpkg -x linux-modules*.deb linux-modules/
 	mkdir -p $(DESTDIR)/dtb
 	cp -r ./build/linux-modules/lib/firmware/*-generic/device-tree/* \

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install/grub:
 	rm -rf build
 	mkdir build
 	# Monolithic images are not yet backported to Ubuntu 22.04.
-	cd build && pull-lp-debs -a riscv64 grub2 '' oracular
+	cd build && pull-lp-debs -a riscv64 grub2 $(SERIES)
 	cd build && dpkg -x grub-efi-riscv64-unsigned*.deb grub/
 	mkdir -p $(DESTDIR)/grub
 	cp ./build/grub/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi $(DESTDIR)/grub/
@@ -45,7 +45,7 @@ install/u-boot:
 	rm -rf build
 	mkdir build
 	rm -rf build/u-boot-sifive*
-	cd build && pull-lp-debs -a riscv64 u-boot '' $(SERIES)
+	cd build && pull-lp-debs -a riscv64 u-boot $(SERIES)
 	# SiFive HiFive Unmatched
 	cd build && dpkg -x u-boot-sifive*.deb u-boot-sifive/
 	mkdir -p $(DESTDIR)/u-boot-sifive-unmatched


### PR DESCRIPTION
This pull requests adds a basic CI/CD pipeline, allowing to build a basic image using the cookbook and upload it as an artifact.

It allows for basic testing of the cookbook, as failing to build the image will fail the pipeline.
However, I'm not sure how we could completely test the images, as it can be difficult to instrumentalize QEMU. That could be a future improvement. :)