### PR TITLE
CI: Add automatic image testing on the pipeline

### DIFF
--- a/.github/workflows/test-first-image.yaml
+++ b/.github/workflows/test-first-image.yaml
@@ -30,5 +30,7 @@ jobs:
         run: sudo ubuntu-image --workdir work --debug classic image-definition.yaml
       - name: Install test dependencies
         run: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python3-pexpect opensbi qemu-system-riscv64 u-boot-qemu
+      - name: Set image permissions
+        run: sudo chown $USER work/ubuntu-24.04-preinstalled-server-riscv64.img
       - name: Test image
         run: python .github/workflows/test.py work/ubuntu-24.04-preinstalled-server-riscv64.img

--- a/.github/workflows/test-first-image.yaml
+++ b/.github/workflows/test-first-image.yaml
@@ -28,13 +28,7 @@ jobs:
         run: sudo snap install --classic ubuntu-image
       - name: Build image
         run: sudo ubuntu-image --workdir work --debug classic image-definition.yaml
-      - name: Upload image as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ubuntu-24.04-preinstalled-server-riscv64.img
-          path: work/ubuntu-24.04-preinstalled-server-riscv64.img
-      - name: Upload manifest as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ubuntu-24.04-preinstalled-server-riscv64.manifest
-          path: work/ubuntu-24.04-preinstalled-server-riscv64.manifest
+      - name: Install test dependencies
+        run: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python3-pexpect opensbi qemu-system-riscv64 u-boot-qemu
+      - name: Test image
+        run: python .github/workflows/test.py work/ubuntu-24.04-preinstalled-server-riscv64.img

--- a/.github/workflows/test.py
+++ b/.github/workflows/test.py
@@ -1,11 +1,17 @@
 #!/usr/bin/python3
 """ Test an image """
+""" Usage: python test.py <image> [debug] """
 
 import pexpect
 import sys
 
 def main():
     image = sys.argv[1]
+    debug = (sys.argv[2] == "debug") if len(sys.argv) >= 3 else False
+
+    if debug:
+        print("Enabling debug mode.")
+
     print(f"Testing image '{image}'. Starting qemu...")
     p = pexpect.spawn(f'qemu-system-riscv64 \
         -machine virt -nographic -m 2048 -smp 4 \
@@ -15,9 +21,12 @@ def main():
         -device virtio-rng-pci \
         -drive file={image},format=raw,if=virtio'
     )
+    
+    if debug:
+        p.logfile = sys.stdout.buffer
         
     print("Waiting for the virtual machine to boot in qemu...")
-    p.expect("ubuntu login:", timeout=120)
+    p.expect("Cloud-init v.* finished", timeout=120)
     print("Found ubuntu login prompt, trying to log in...")
     p.sendline("ubuntu")
     p.expect("Password:")

--- a/.github/workflows/test.py
+++ b/.github/workflows/test.py
@@ -26,7 +26,7 @@ def main():
         p.logfile = sys.stdout.buffer
         
     print("Waiting for the virtual machine to boot in qemu...")
-    p.expect("Cloud-init v.* finished", timeout=120)
+    p.expect("Cloud-init v.* finished", timeout=240)
     print("Found ubuntu login prompt, trying to log in...")
     p.sendline("ubuntu")
     p.expect("Password:")

--- a/.github/workflows/test.py
+++ b/.github/workflows/test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+""" Test an image """
+
+import pexpect
+import sys
+
+def main():
+    image = sys.argv[1]
+    print(f"Testing image '{image}'. Starting qemu...")
+    p = pexpect.spawn(f'qemu-system-riscv64 \
+        -machine virt -nographic -m 2048 -smp 4 \
+        -bios /usr/lib/riscv64-linux-gnu/opensbi/generic/fw_jump.bin \
+        -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf \
+        -device virtio-net-device,netdev=eth0 -netdev user,id=eth0 \
+        -device virtio-rng-pci \
+        -drive file={image},format=raw,if=virtio'
+    )
+        
+    print("Waiting for the virtual machine to boot in qemu...")
+    p.expect("ubuntu login:", timeout=120)
+    print("Found ubuntu login prompt, trying to log in...")
+    p.sendline("ubuntu")
+    p.expect("Password:")
+    p.sendline("ubuntu")
+    print("Login information sent ! Waiting for 'change password' prompt...")
+
+    # Change password
+    p.expect("Current password:")
+    print("Changing password...")
+    p.sendline("ubuntu")
+    p.expect("New password:")
+    p.sendline("again-ubuntu")
+    p.expect("Retype new password:")
+    p.sendline("again-ubuntu")
+
+    # Shell access
+    p.expect("ubuntu@ubuntu:~")
+    print("Shell access obtained, image ok.")
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/test.py
+++ b/.github/workflows/test.py
@@ -26,8 +26,12 @@ def main():
         p.logfile = sys.stdout.buffer
         
     print("Waiting for the virtual machine to boot in qemu...")
-    p.expect("Cloud-init v.* finished", timeout=240)
-    print("Found ubuntu login prompt, trying to log in...")
+    expects = ["Cloud-init v.* finished", "ubuntu login:"]
+    found = p.expect(expects, timeout=240)
+    print(f"Found '{expects[found]}', waiting for '{expects[1 - found]}'...")
+    p.expect(expects[1 - found], timeout=60)
+    
+    print("Machine initialization done, trying to log in...")
     p.sendline("ubuntu")
     p.expect("Password:")
     p.sendline("ubuntu")


### PR DESCRIPTION
This pull requests adds automatic image testing to the pipeline.
It uses a python script with the pexpect module, and boots the image using qemu, waits for cloud-init to finish, logs in, changes the default password and waits for a shell prompt. If everything works, the test passes, else it fails.