### PR TITLE
Update the cookbook for stonking

### DIFF
--- a/.github/workflows/test-first-image.yaml
+++ b/.github/workflows/test-first-image.yaml
@@ -3,25 +3,29 @@
 name: Build and test
 
 # We allow running workflows on main, and on the 'ci' special branch used to work
-# on ci/cd workflows.
+# on ci/cd workflows. Also allow on LTS branches.
 on:
   push:
     branches:
       - main
       - ci
+      - resolute
+      - noble
   pull_request:
     branches:
       - main
       - ci
+      - resolute
+      - noble
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
       - name: Install apt dependencies
-        run: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y snapd qemu-user-static ubuntu-dev-tools
+        run: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y snapd qemu-user-binfmt ubuntu-dev-tools
       - name: Refresh systemd-binfmt
         run: sudo systemctl restart systemd-binfmt
       - name: Install ubuntu-image
@@ -29,8 +33,8 @@ jobs:
       - name: Build image
         run: sudo ubuntu-image --workdir work --debug classic image-definition.yaml
       - name: Install test dependencies
-        run: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python3-pexpect opensbi qemu-system-riscv64 u-boot-qemu
+        run: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y python3-pexpect opensbi qemu-system-riscv qemu-efi-riscv64 u-boot-qemu
       - name: Set image permissions
-        run: sudo chown $USER work/ubuntu-24.04-preinstalled-server-riscv64.img
+        run: sudo chown $USER work/ubuntu-26.04-preinstalled-server-riscv64.img
       - name: Test image
-        run: python .github/workflows/test.py work/ubuntu-24.04-preinstalled-server-riscv64.img
+        run: python .github/workflows/test.py work/ubuntu-26.04-preinstalled-server-riscv64.img

--- a/.github/workflows/test.py
+++ b/.github/workflows/test.py
@@ -3,7 +3,9 @@
 """ Usage: python test.py <image> [debug] """
 
 import pexpect
+import shutil
 import sys
+from pathlib import Path
 
 def main():
     image = sys.argv[1]
@@ -12,14 +14,26 @@ def main():
     if debug:
         print("Enabling debug mode.")
 
+    print(f"Setting up EFI variables...")
+    vars_src = Path("/usr/share/qemu-efi-riscv64/RISCV_VIRT_VARS.fd")
+    vars_dst = Path("RISCV_VIRT_VARS.fd")
+    if vars_src.exists():
+        shutil.copy(vars_src, vars_dst)
+        print(f"Copied {vars_src} to {vars_dst}")
+    elif not vars_dst.exists():
+        print(f"Error: {vars_src} not found and {vars_dst} not present.", file=sys.stderr)
+        sys.exit(1)
+
     print(f"Testing image '{image}'. Starting qemu...")
-    p = pexpect.spawn(f'qemu-system-riscv64 \
-        -machine virt -nographic -m 2048 -smp 4 \
-        -bios /usr/lib/riscv64-linux-gnu/opensbi/generic/fw_jump.bin \
-        -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf \
-        -device virtio-net-device,netdev=eth0 -netdev user,id=eth0 \
-        -device virtio-rng-pci \
-        -drive file={image},format=raw,if=virtio'
+    p = pexpect.spawn(
+        f'qemu-system-riscv64 '
+        f'-cpu rva23s64 '
+        f'-machine virt -nographic -m 2048 -smp 4 '
+        f'-drive if=pflash,format=raw,unit=0,file=/usr/share/qemu-efi-riscv64/RISCV_VIRT_CODE.fd,readonly=on '
+        f'-drive if=pflash,format=raw,unit=1,file=RISCV_VIRT_VARS.fd,readonly=off '
+        f'-device virtio-net-device,netdev=eth0 -netdev user,id=eth0 '
+        f'-device virtio-rng-pci '
+        f'-drive file={image},format=raw,if=virtio'
     )
     
     if debug:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-SERIES ?= noble
+SERIES ?= resolute
 DESTDIR ?= install
 
 all:
@@ -8,7 +8,6 @@ all:
 	make install/dtb
 	make install/grub
 	make meta
-	make install/u-boot
 
 meta:
 	mkdir -p $(DESTDIR)/meta
@@ -26,44 +25,22 @@ install/dtb:
 	cd build && pull-lp-debs -a riscv64 linux-riscv $(SERIES)
 	cd build && dpkg -x linux-modules*.deb linux-modules/
 	mkdir -p $(DESTDIR)/dtb
-	cp -r ./build/linux-modules/lib/firmware/*-generic/device-tree/* \
-	$(DESTDIR)/dtb
+	# Copy DTBs to destination, only if kernel has DTBS
+	for dir in ./build/linux-modules/lib/firmware/*-generic/device-tree; do \
+		if [ -d "$$dir" ]; then \
+			cp -r "$$dir"/* $(DESTDIR)/dtb; \
+		fi; \
+	done
 	rm -rf build
 
 install/grub:
 	rm -rf build
 	mkdir build
 	cd build && pull-lp-debs -a riscv64 grub2 $(SERIES)
-	cd build && dpkg -x grub-efi-riscv64-bin*.deb grub/
+	cd build && dpkg -x grub-efi-riscv64-unsigned*.deb grub/
 	mkdir -p $(DESTDIR)/grub
 	cp ./build/grub/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi $(DESTDIR)/grub/
 	cp grub.cfg $(DESTDIR)/grub/
-	rm -rf build
-
-install/u-boot:
-	rm -rf build
-	mkdir build
-	rm -rf build/u-boot-sifive*
-	cd build && pull-lp-debs -a riscv64 u-boot $(SERIES)
-	# SiFive HiFive Unmatched
-	cd build && dpkg -x u-boot-sifive*.deb u-boot-sifive/
-	mkdir -p $(DESTDIR)/u-boot-sifive-unmatched
-	cp ./build/u-boot-sifive/usr/lib/u-boot/sifive_unmatched/u-boot-spl.bin \
-	$(DESTDIR)/u-boot-sifive-unmatched/
-	cp ./build/u-boot-sifive/usr/lib/u-boot/sifive_unmatched/u-boot.itb \
-	$(DESTDIR)/u-boot-sifive-unmatched/
-	# JH7110 based boards
-	cd build && dpkg -x u-boot-starfive*.deb u-boot-starfive/
-	mkdir -p $(DESTDIR)/u-boot-starfive
-	cp build/u-boot-starfive/usr/lib/u-boot/starfive_visionfive2/u-boot.itb \
-	$(DESTDIR)/u-boot-starfive/
-	cp build/u-boot-starfive/usr/lib/u-boot/starfive_visionfive2/u-boot-spl.bin.normal.out \
-	$(DESTDIR)/u-boot-starfive/
-	# PolarFire Icicle Kit
-	cd build && dpkg -x u-boot-microchip*.deb u-boot-microchip/
-	mkdir -p $(DESTDIR)/u-boot-microchip
-	cp build/u-boot-microchip/usr/lib/u-boot/microchip_icicle/u-boot.payload \
-	$(DESTDIR)/u-boot-microchip/
 	rm -rf build
 
 image:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-SERIES ?= resolute
+SERIES ?= stonking
 DESTDIR ?= install
 
 all:

--- a/README.rst
+++ b/README.rst
@@ -1,45 +1,7 @@
 RISC-V gadget
 =============
 
-Install dependencies
---------------------
+**Ubuntu 26.04 "Resolute Raccoon" branch**
 
-.. code-block:: bash
-
-    sudo apt-get update
-    sudo apt-get install git snapd qemu-user-static ubuntu-dev-tools
-    sudo snap install --classic ubuntu-image
-
-Build image
------------
-
-.. code-block:: bash
-
-    sudo ubuntu-image --debug classic image-definition.yaml
-
-For debugging add --workdir /tmp/workdir.
-
-First boot
-----------
-
-The image contains U-Boot to boot on:
-
-* Microchip Icicle Kit
-* SiFive HiFive Unmatched
-* StarFive VisionFive 2 1.3b
-
-To boot on QEMU use the following commands:
-
-.. code-block:: bash
-
-    sudo apt-get update
-    sudo apt-get install opensbi qemu-system-misc u-boot-qemu
-    qemu-system-riscv64 \
-    -machine virt -nographic -m 2048 -smp 4 \
-    -bios /usr/lib/riscv64-linux-gnu/opensbi/generic/fw_jump.bin \
-    -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf \
-    -device virtio-net-device,netdev=eth0 -netdev user,id=eth0 \
-    -device virtio-rng-pci \
-    -drive file=ubuntu-24.04-preinstalled-server-riscv64.img,format=raw,if=virtio
-
-Login with user ubuntu, password ubuntu.
+See `Your first Ubuntu image <https://ubuntu.com/hardware/docs/image-cookbook/tutorial/create_image/>`_
+for instructions on how to use this repository.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,12 @@
 RISC-V gadget
 =============
 
-**Ubuntu 26.04 "Resolute Raccoon" branch**
+**Ubuntu Development Release Branch**
 
 See `Your first Ubuntu image <https://ubuntu.com/hardware/docs/image-cookbook/tutorial/create_image/>`_
 for instructions on how to use this repository.
+
+*Looking for LTS branches?*
+
+* `resolute <https://github.com/canonical/risc-v-gadget/tree/resolute>`_
+* `noble <https://github.com/canonical/risc-v-gadget/tree/noble>`_

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -4,35 +4,6 @@ volumes:
     schema: gpt
     bootloader: grub
     structure:
-      - name: sifive_unmatched_u-boot_itb
-        size: 16M
-        # random value for type
-        type: 537B4768-474D-42EB-99C7-D8BCE5A57079
-        offset: 1065984
-        size: 16M
-        content:
-          - image: u-boot-sifive-unmatched/u-boot.itb
-      - name: starfive_visionfive_2_u-boot
-        # random value for type
-        type: 816E2DB1-6FE4-4797-B3FF-2DE37CB85318
-        size: 16M
-        content:
-          - image: u-boot-starfive/u-boot.itb
-      - name: sifive_unmatched_u-boot-spl
-        type: 5B193300-FC78-40CD-8002-E86C45580B47
-        size: 1M
-        content:
-          - image: u-boot-sifive-unmatched/u-boot-spl.bin
-      - name: starfive_visionfive_2_u-boot-spl
-        type: 2E54B353-1271-4842-806F-E436D6AF6985
-        size: 1M
-        content:
-          - image: u-boot-starfive/u-boot-spl.bin.normal.out
-      - name: microchip_icicle_u-boot
-        type: 21686148-6449-6E6F-744E-656564454649
-        size: 16M
-        content:
-          - image: u-boot-microchip/u-boot.payload
       - name: EFI System
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat

--- a/image-definition.yaml
+++ b/image-definition.yaml
@@ -3,13 +3,13 @@ name: ubuntu-server-riscv64-preinstalled
 display-name: Ubuntu Server RISC-V preinstalled
 revision: 1
 architecture: riscv64
-series: resolute
+series: stonking
 class: preinstalled
 kernel: linux-image-generic
 gadget:
   url: "file://."
   type: "git"
-  branch: "resolute"
+  branch: "main"
 rootfs:
   archive: ubuntu
   sources-list-deb822: true
@@ -23,7 +23,7 @@ rootfs:
   seed:
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
-    branch: resolute
+    branch: stonking
     names:
       - cloud-image
       - server
@@ -49,6 +49,6 @@ customization:
       fsck-order: 1
 artifacts:
   img:
-    - name: ubuntu-26.04-preinstalled-server-riscv64.img
+    - name: ubuntu-26.10-preinstalled-server-riscv64.img
   manifest:
-    name: ubuntu-26.04-preinstalled-server-riscv64.manifest
+    name: ubuntu-26.10-preinstalled-server-riscv64.manifest

--- a/image-definition.yaml
+++ b/image-definition.yaml
@@ -3,13 +3,13 @@ name: ubuntu-server-riscv64-preinstalled
 display-name: Ubuntu Server RISC-V preinstalled
 revision: 1
 architecture: riscv64
-series: noble
+series: resolute
 class: preinstalled
 kernel: linux-image-generic
 gadget:
-  url: "https://github.com/canonical/risc-v-gadget.git"
+  url: "file://."
   type: "git"
-  branch: "main"
+  branch: "resolute"
 rootfs:
   archive: ubuntu
   sources-list-deb822: true
@@ -23,7 +23,7 @@ rootfs:
   seed:
     urls:
       - "https://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
-    branch: noble
+    branch: resolute
     names:
       - cloud-image
       - server
@@ -49,6 +49,6 @@ customization:
       fsck-order: 1
 artifacts:
   img:
-    - name: ubuntu-24.04-preinstalled-server-riscv64.img
+    - name: ubuntu-26.04-preinstalled-server-riscv64.img
   manifest:
-    name: ubuntu-24.04-preinstalled-server-riscv64.manifest
+    name: ubuntu-26.04-preinstalled-server-riscv64.manifest


### PR DESCRIPTION
This updates the main branch of the Cookbook for Ubuntu 26.10 Stonking Stingray, the current development release.

Even though the release is not out yet, I believe it is important on the main development branch to be able to produce and test current development release images.
Added LTS branches like 'resolute' and 'noble' for more stable images.

Thoughts?